### PR TITLE
[FIX] potential memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/*
 .env
 tmp/*
 .DS_Store
+
+package-lock.json

--- a/bin/lib/run-ffmpeg.js
+++ b/bin/lib/run-ffmpeg.js
@@ -7,8 +7,6 @@ module.exports = function(args){
 	debug('\n\n', ffmpeg.path, args.join(' '), '\n\n');
 
 	return new Promise( ( resolve, reject) => {
-
-		let output = '';
 		const process = spawn(ffmpeg.path, args);
 
 		process.stdout.on('data', (data) => {
@@ -17,7 +15,6 @@ module.exports = function(args){
 
 		process.stderr.on('data', (data) => {
 			debug(`stderr: ${data}`);
-			output += data + '\n';
 		});
 
 		process.on('close', (code) => {
@@ -27,7 +24,7 @@ module.exports = function(args){
 				reject('');
 			} else if(code === 0){
 				debug('FFMPEG closed and was happy');
-				resolve(output);
+				resolve();
 			}
 
 		});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "@financial-times/s3o-middleware": "^2.0.5",
     "aws-sdk": "^2.7.13",
     "body-parser": "~1.15.1",
     "cookie-parser": "~1.4.3",
@@ -18,7 +19,6 @@
     "md5": "^2.2.1",
     "morgan": "~1.7.0",
     "node-fetch": "^1.6.3",
-    "s3o-middleware": "^1.8.0",
     "serve-favicon": "~2.3.0",
     "shortid": "^2.2.6",
     "unidecode": "^0.1.8"

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const authS3O = require('s3o-middleware');
+const authS3O = require('@financial-times/s3o-middleware');
 
 const services = require('../bin/lib/list-services');
 


### PR DESCRIPTION
- updated s3o middleware to use `@financialtimes` version
- remove `output` var in `run-ffmpeg` as it is not used and could cause memory leaks as there is no cap on its length.